### PR TITLE
bugfix: DNP allow missing/no markings

### DIFF
--- a/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/DigitalNameplate.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/DigitalNameplate.vue
@@ -368,7 +368,7 @@ export default defineComponent({
         extractMarkings(digitalNameplateData: any) {
             let markings = digitalNameplateData.submodelElements.find((element: any) => element.idShort === 'Markings');
             let formattedMarkings = [] as Array<any>;
-            if (markings) {
+            if (markings?.value) {
                 markings.value.forEach((marking: any) => {
                     // find property with the idShort "MarkingFile"
                     let markingFile = marking.value.find((element: any) => element.idShort === 'MarkingFile');


### PR DESCRIPTION
When markings are missing/empty the GUI shows nothing / crashes. Using optional chaining makes it a bit more forgiving.