### PR TITLE
Fix defaultThumbnail path of asset

### DIFF
--- a/aas-gui/Frontend/aas-web-gui/src/components/AppNavigation/AASListDetails.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/AppNavigation/AASListDetails.vue
@@ -99,7 +99,13 @@ export default defineComponent({
             this.getRequest(path, context, disableMessage).then((response: any) => {
                 if (response.success) {
                     // console.log('asset information: ', response.data);
-                    this.assetInformation = response.data;
+                    let assetInformation = response.data;
+                    if (assetInformation.defaultThumbnail && assetInformation.defaultThumbnail.path && !assetInformation.defaultThumbnail.path.startsWith('http')) {
+                        let assetInformationThumbnailEndpoint = assetInformationEndpoint + '/thumbnail';
+                        assetInformation.defaultThumbnail.path = assetInformationThumbnailEndpoint;
+                    }
+                    // console.log('asset information thumbnail: ', assetInformation.defaultThumbnail);
+                    this.assetInformation = assetInformation;
                 }
             });
         },


### PR DESCRIPTION
There seems to be an error when the default thumbnail of the asset is displayed.

The thumbnail is displayed when the path is specified as URL:
<img width="750" alt="Bildschirmfoto 2024-05-22 um 12 42 32" src="https://github.com/eclipse-basyx/basyx-applications/assets/2117267/12e13561-de5b-4234-864e-e76a67fc45f6">

However, if the thumbnail is specified as a file (in an aasx package), it will not be displayed:
<img width="750" alt="Bildschirmfoto 2024-05-22 um 12 46 48" src="https://github.com/eclipse-basyx/basyx-applications/assets/2117267/e7435802-a3b7-4e36-b0ae-3596445abdbf">

I've fixed the path (if thumbnail is specified as file) with respect to [DotAAS Part 2 | HTTP/REST | Asset Administration Shell Repository Service Specification](https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellRepositoryServiceSpecification/V3.0.1_SSP-001#/Asset%20Administration%20Shell%20Repository%20API/GetThumbnail_AasRepository):
<img width="750" alt="Bildschirmfoto 2024-05-22 um 12 56 47" src="https://github.com/eclipse-basyx/basyx-applications/assets/2117267/1a46b428-8227-43d2-8b2b-88c08eec19f7">
