### PR TITLE
Add unit suffix to property text-field in SubmodelElementGroup

### DIFF
--- a/aas-gui/Frontend/aas-web-gui/src/components/UIComponents/SubmodelElementGroup.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/UIComponents/SubmodelElementGroup.vue
@@ -38,6 +38,9 @@
                                 <template v-slot:prepend-inner>
                                     <v-chip label size="x-small" border color="primary">{{ SubmodelElement.valueType }}</v-chip>
                                 </template>
+                                <template v-slot:append-inner>
+                                    <span class="text-subtitleText">{{ unitSuffix(SubmodelElement) }}</span>
+                                </template>
                             </v-text-field>
                             <!-- MultiLanguageProperty -->
                             <DescriptionElement v-else-if="SubmodelElement.modelType == 'MultiLanguageProperty'" :descriptionObject="SubmodelElement.value" :descriptionTitle="nameToDisplay(SubmodelElement)" :small="false" style="margin-top: -12px"></DescriptionElement>
@@ -158,6 +161,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { useAASStore } from '@/store/AASDataStore';
+import SubmodelElementHandling from '@/mixins/SubmodelElementHandling';
 import DescriptionElement from './DescriptionElement.vue';
 
 export default defineComponent({
@@ -165,6 +169,7 @@ export default defineComponent({
     components: {
         DescriptionElement,
     },
+    mixins: [SubmodelElementHandling],
     props: ['smeObject', 'smeLocator', 'topMargin'],
 
     setup() {

--- a/aas-gui/Frontend/aas-web-gui/src/mixins/SubmodelElementHandling.ts
+++ b/aas-gui/Frontend/aas-web-gui/src/mixins/SubmodelElementHandling.ts
@@ -476,6 +476,11 @@ export default defineComponent({
         // Get the Unit from the EmbeddedDataSpecification of the ConceptDescription of the Property (if available)  
         unitSuffix(prop: any) {
             if (!prop.conceptDescriptions) {
+                this.getConceptDescriptions(prop).then(conceptDescriptions => {
+                    prop.conceptDescriptions = conceptDescriptions;
+                });
+            }
+            if (!prop.conceptDescriptions || prop.conceptDescriptions.length == 0) {
                 return '';
             }
             for (const conceptDescription of prop.conceptDescriptions) {


### PR DESCRIPTION
## Description of Changes

Unlike in the [Property view](https://github.com/eclipse-basyx/basyx-applications/blob/main/aas-gui/Frontend/aas-web-gui/src/components/SubmodelElements/Property.vue) (see [NumberType.vue](https://github.com/eclipse-basyx/basyx-applications/blob/main/aas-gui/Frontend/aas-web-gui/src/components/SubmodelElements/ValueTypes/NumberType.vue#L13)), the unit of a property is not displayed in the [SubmodelElementGroup view](https://github.com/eclipse-basyx/basyx-applications/blob/main/aas-gui/Frontend/aas-web-gui/src/components/UIComponents/SubmodelElementGroup.vue#L36C29-L41C44):

<kbd><img width="500" alt="Bildschirmfoto 2024-06-15 um 11 26 44" src="https://github.com/eclipse-basyx/basyx-applications/assets/2117267/e53d8804-1f8e-4e26-839c-8c843434b122"></kbd>
<kbd><img width="500" alt="Bildschirmfoto 2024-06-15 um 11 26 54" src="https://github.com/eclipse-basyx/basyx-applications/assets/2117267/9e27804c-93dd-4bfb-8256-3b867a373ab5"></kbd>



This PR adds the unit suffix for properties in the SubmodelElementGroup.vue:
<kbd><img width="500" alt="Bildschirmfoto 2024-06-15 um 11 27 27" src="https://github.com/eclipse-basyx/basyx-applications/assets/2117267/1efad4cc-6023-498e-a84a-c58a3184b56d"></kbd>


## Related Issue

None

## BaSyx Configuration for Testing

Default configuration of aas-environment, aas-registry, sm-registry, aas-discovery and aas-gui (see [BaSyx Starter Kit](https://basyx.org/#/get-started))

## AAS Files Used for Testing

[TechnicalDataDemo.aasx.zip](https://github.com/user-attachments/files/15846360/TechnicalDataDemo.aasx.zip)

## Additional Information

None