### PR TITLE
Fixes Wrong Request URL when deleting an AAS in the AAS Web GUI

### DIFF
--- a/aas-gui/Frontend/aas-web-gui/src/components/AppNavigation/AASList.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/AppNavigation/AASList.vue
@@ -410,7 +410,7 @@ export default defineComponent({
                 if (!this.aasRegistryURL.includes('/shell-descriptors')) {
                     this.aasRegistryURL += '/shell-descriptors';
                 }
-                let path = this.aasRegistryURL + this.URLEncode(AAS.id);
+                let path = this.aasRegistryURL + '/' + this.URLEncode(AAS.id);
                 let context = 'removing AAS from AAS Registry';
                 let disableMessage = false;
                 this.deleteRequest(path, context, disableMessage).then((response: any) => {


### PR DESCRIPTION
# Pull Request Template

## Description of Changes

Fixes Wrong Request URL when deleting an AAS in the AAS Web GUI by adding missing slash in request URL

## Related Issue

Closes #173
