### PR TITLE
Updates MLP to use PATCH $value

### DIFF
--- a/aas-gui/Frontend/aas-web-gui/src/components/SubmodelElements/MultiLanguageProperty.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/SubmodelElements/MultiLanguageProperty.vue
@@ -164,13 +164,13 @@ export default defineComponent({
         // Function to update the value of the property
         updateMLP() {
             // console.log("Update Value: ", this.multiLanguagePropertyObject);
-            let path = this.multiLanguagePropertyObject.path;
-            let content = JSON.stringify(this.multiLanguagePropertyObject);
+            let path = this.multiLanguagePropertyObject.path + '/$value';
+            let content = JSON.stringify(this.multiLanguagePropertyObject.value.map((item: any) => ({ [item.language]: item.text })));
             let headers = { 'Content-Type': 'application/json' };
-                let context = 'updating ' + this.multiLanguagePropertyObject.modelType + ' "' + this.multiLanguagePropertyObject.idShort + '"';
+            let context = 'updating ' + this.multiLanguagePropertyObject.modelType + ' "' + this.multiLanguagePropertyObject.idShort + '"';
             let disableMessage = false;
             // Send Request to update the value of the property
-            this.putRequest(path, content, headers, context, disableMessage).then((response: any) => {
+            this.patchRequest(path, content, headers, context, disableMessage).then((response: any) => {
                 if (response.success) {
                     // // this.newPropertyValue = ''; // reset input
                     // let updatedPropertyObject = { ...this.propertyObject }; // copy the propertyObject


### PR DESCRIPTION
# Updating a MultilanguageProperty now uses the PATCH $value endpoint

## Description of Changes

Updating a MultilanguageProperty now uses the PATCH $value endpoint.

## Related Issue

Closes #175 