### PR TITLE
Fixes File Attachments when using MongoDB backend

### DIFF
--- a/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/ContactInformation.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/ContactInformation.vue
@@ -98,10 +98,10 @@ export default defineComponent({
     },
 
     methods: {
-        initContactInformation() {
+        async initContactInformation() {
             // console.log('Initialize Contact Information Plugin: ', this.submodelElementData);
             let submodelElementData = { ...this.submodelElementData };
-            submodelElementData = this.calculateSubmodelElementPathes(submodelElementData, this.SelectedNode.path);
+            submodelElementData = await this.calculateSubmodelElementPathes(submodelElementData, this.SelectedNode.path);
             // create array of contacts
             let contacts = this.submodelElementData.submodelElements.filter((element: any) => {
                 return element.semanticId.keys[0].value === 'https://admin-shell.io/zvei/nameplate/1/0/ContactInformations/ContactInformation';

--- a/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/DigitalNameplate.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/DigitalNameplate.vue
@@ -190,14 +190,14 @@ export default defineComponent({
 
     methods: {
         // Function to initialize the Digital Nameplate
-        initializeDigitalNameplate() {
+        async initializeDigitalNameplate() {
             // Check if a Node is selected
             if (Object.keys(this.submodelElementData).length == 0) {
                 this.digitalNameplateData = {}; // Reset the DigitalNameplate Data when no Node is selected
                 return;
             }
             let digitalNameplateData = { ...this.submodelElementData }; // create local copy of the Nameplate Object
-            this.digitalNameplateData = this.calculateSubmodelElementPathes(digitalNameplateData, this.SelectedNode.path); // Set the DigitalNameplate Data
+            this.digitalNameplateData = await this.calculateSubmodelElementPathes(digitalNameplateData, this.SelectedNode.path); // Set the DigitalNameplate Data
             // console.log('Digital Nameplate Data:', this.digitalNameplateData);
             this.extractProductProperties(digitalNameplateData); // Extract the Product Properties
             this.extractManufacturerProperties(digitalNameplateData); // Extract the Manufacturer Properties

--- a/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/HandoverDocumentation.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/HandoverDocumentation.vue
@@ -201,10 +201,10 @@ export default defineComponent({
     },
 
     methods: {
-        initHandoverDocumentation() {
+        async initHandoverDocumentation() {
             // console.log('Initialize Handover Documentation Plugin: ', this.submodelElementData);
             let submodelElementData = { ...this.submodelElementData };
-            submodelElementData = this.calculateSubmodelElementPathes(submodelElementData, this.SelectedNode.path);
+            submodelElementData = await this.calculateSubmodelElementPathes(submodelElementData, this.SelectedNode.path);
             // create array of documents
             let documents = this.submodelElementData.submodelElements.filter((element: any) => {
                 return element.semanticId.keys[0].value.includes("0173-1#02-ABI500#001/0173-1#01-AHF579#001");
@@ -262,11 +262,14 @@ export default defineComponent({
 
         getLocalPath(value: string, path: string): string {
             if (!value) return '';
-            // check if Link starts with '/'
-            if (value.startsWith('/')) {
-                path = path + '/attachment';
+            try {
+                new URL(value);
+                // If no error is thrown, path is a valid URL
+                return value;
+            } catch {
+                // If error is thrown, path is not a valid URL
+                return `${path}/attachment`;
             }
-            return path;
         },
     },
 });

--- a/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/PDFPreview.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/PDFPreview.vue
@@ -73,16 +73,21 @@ export default defineComponent({
         getLocalPath(path: string): string {
             this.useIFrame = true;
             if (!path) return '';
-            // check if Link starts with '/'
-            if (path.startsWith('/')) {
-                path = this.submodelElementData.path + '/attachment';
+
+            try {
+                new URL(path);
+                // If no error is thrown, path is a valid URL
+                return path;
+            } catch {
+                // If error is thrown, path is not a valid URL
+                if(!path.endsWith('.pdf') && path.endsWith('/File')) {
+                    this.useIFrame = false;
+                    this.getPDFData();
+                    return path;
+                } else {
+                    return `${this.submodelElementData.path}/attachment`;
+                }
             }
-            // check if path has not .pdf at the end and instead /File
-            if (!path.endsWith('.pdf') && path.endsWith('/File')) {
-                this.useIFrame = false;
-                this.getPDFData();
-            }
-            return path;
         },
 
         // Function to fetch raw PDF data

--- a/aas-gui/Frontend/aas-web-gui/src/components/UIComponents/SubmodelElementGroup.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/UIComponents/SubmodelElementGroup.vue
@@ -55,11 +55,6 @@
                                 <template v-slot:prepend-inner>
                                     <v-chip label size="x-small" border color="primary">{{ SubmodelElement.modelType }}</v-chip>
                                 </template>
-                                <template v-slot:append-inner>
-                                    <v-btn :disabled="!SubmodelElement.value" size="small" variant="elevated" color="primary" class="text-buttonText" style="right: -4px" @click.stop="downloadFile(SubmodelElement.value)">
-                                        <v-icon>mdi-download</v-icon>
-                                    </v-btn>
-                                </template>
                             </v-text-field>
                             <!-- Blob -->
                             <v-text-field v-else-if="SubmodelElement.modelType == 'Blob'" :label="nameToDisplay(SubmodelElement)" density="compact" variant="outlined" v-model="SubmodelElement.value" readonly hide-details>
@@ -204,22 +199,6 @@ export default defineComponent({
                 return keys[keys.length - 1].value;
             }
             return '';
-        },
-
-        // Function to download a file
-        downloadFile(link: string) {
-            // open new tab with file
-            window.open(this.getLocalPath(link), '_blank');
-        },
-
-        // Function to prepare the Image Link for the Image Preview
-        getLocalPath(path: string): string {
-            if (!path) return '';
-            // check if Link starts with '/'
-            if (path.startsWith('/')) {
-                path = this.SelectedAAS.endpoints[0].protocolInformation.href.replace('/aas', '') + '/files' + path;
-            }
-            return path;
         },
     },
 });

--- a/aas-gui/Frontend/aas-web-gui/src/mixins/SubmodelElementHandling.ts
+++ b/aas-gui/Frontend/aas-web-gui/src/mixins/SubmodelElementHandling.ts
@@ -466,11 +466,15 @@ export default defineComponent({
         // Function to calculate the local path (used for files)
         getLocalPath(path: string, selectedNode: any): string {
             if (!path) return '';
-            // check if Link starts with '/'
-            if (path.startsWith('/')) {
-                path = selectedNode.path + '/attachment';
+        
+            try {
+                new URL(path);
+                // If no error is thrown, path is a valid URL
+                return path;
+            } catch {
+                // If error is thrown, path is not a valid URL
+                return `${selectedNode.path}/attachment`;
             }
-            return path;
         },
 
         // Get the Unit from the EmbeddedDataSpecification of the ConceptDescription of the Property (if available)  


### PR DESCRIPTION
# Fixes File Attachments

This PR fixes the handling of file attachments. The path for supplemental files when using MongoDB as backend does not include a "/" in the beginning. This caused problems in determining if the path of a file SubmodelElement refers to an external file or one located in the BaSyx backend (InMemory/MongoDB).
