### PR TITLE
Support Visualization of SM HierarchicalStructures v1.1

### DIFF
--- a/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/_SubmodelEntrypoint.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/_SubmodelEntrypoint.vue
@@ -5,7 +5,7 @@
             <HTWFuehrungskomponente v-if="checkSemanticId('http://htw-berlin.de/smc_statemachine')" :submodelElementData="submodelElementData" :selectedNode="selectedNode"></HTWFuehrungskomponente>
             <DigitalNameplate v-else-if="checkSemanticId('https://admin-shell.io/zvei/nameplate/2/0/Nameplate')" :submodelElementData="submodelElementData"></DigitalNameplate>
             <TimeSeriesData v-else-if="checkSemanticId('https://admin-shell.io/idta/TimeSeries/1/1')" :submodelElementData="submodelElementData"></TimeSeriesData>
-            <BillsOfMaterial v-else-if="checkSemanticId('https://admin-shell.io/idta/HierarchicalStructures/1/0/Submodel')" :submodelElementData="submodelElementData"></BillsOfMaterial>
+            <BillsOfMaterial v-else-if="checkSemanticId('https://admin-shell.io/idta/HierarchicalStructures/1/0/Submodel') || checkSemanticId('https://admin-shell.io/idta/HierarchicalStructures/1/1/Submodel')" :submodelElementData="submodelElementData"></BillsOfMaterial>
             <HandoverDocumentation v-else-if="checkSemanticId('0173-1#01-AHF578#001')" :submodelElementData="submodelElementData"></HandoverDocumentation>
             <ContactInformation v-else-if="checkSemanticId('https://admin-shell.io/zvei/nameplate/1/0/ContactInformations')" :submodelElementData="submodelElementData"></ContactInformation>
             <TechnicalData v-else-if="checkSemanticId('https://admin-shell.io/ZVEI/TechnicalData/Submodel/1/2')" :submodelElementData="submodelElementData"></TechnicalData>


### PR DESCRIPTION
## Description of Changes

Adapt check of semanticId for SM HierarchicalStructures v1.1 to support its visualization

## Additional Information

SM HierarchicalStrucutures v1.1 was published a few weeks ago: https://github.com/admin-shell-io/submodel-templates/tree/main/published/Hierarchical%20Structures%20enabling%20Bills%20of%20Material/1/1

Version 1.1 does not contain any relevant changes compared to version 1.0, but semanticId has been changed.