### PR TITLE
Fixes Generic Submodel Visualization not working in mobile view

### DIFF
--- a/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/_SubmodelEntrypoint.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/_SubmodelEntrypoint.vue
@@ -95,7 +95,7 @@ export default defineComponent({
         // return if in viewer mode
         viewerMode() {
             // check if the route name is aasviewer
-            return this.$route.name === 'AASViewer';
+            return this.$route.name === 'AASViewer' || this.$route.name === 'ComponentVisualization';
         },
     },
 


### PR DESCRIPTION
## Description of Changes

The Submodel Visualization was not shown for Submodels that do not fit a Template in the mobile View.

## Related Issue

None.

## BaSyx Configuration for Testing

[basyx-setup.zip](https://github.com/user-attachments/files/16159743/basyx-setup.zip)

## AAS Files Used for Testing

Included in setup

## Additional Information

None

---

Please ensure that you have tested your changes thoroughly before submitting the pull request.
