### PR TITLE
Check of semanticId

### DIFF
--- a/aas-gui/Frontend/aas-web-gui/src/components/Dashboard/DashboardEditElement.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/Dashboard/DashboardEditElement.vue
@@ -29,7 +29,7 @@
                         </template>
                     </v-combobox>
                     <template v-if="aasData && Object.keys(aasData).length > 0">
-                        <TimeSeriesData v-if="checkSemanticId('https://admin-shell.io/idta/TimeSeries/1/1')" class="py-2" :submodelElementData="aasData" :configData="dashboardData" :editDialog="true" @newOptions="setNewOptions"></TimeSeriesData>
+                        <TimeSeriesData v-if="checkSemanticId(dashboardData.configObject, 'https://admin-shell.io/idta/TimeSeries/1/1')" class="py-2" :submodelElementData="aasData" :configData="dashboardData" :editDialog="true" @newOptions="setNewOptions"></TimeSeriesData>
                     </template>
                 </v-card-text>
                 <v-divider></v-divider>
@@ -46,6 +46,7 @@
     import { defineComponent } from 'vue';
     import { useEnvStore } from '@/store/EnvironmentStore';
     import DashboardHandling from '@/mixins/DashboardHandling';
+    import SubmodelElementHandling from '@/mixins/SubmodelElementHandling';
     import TimeSeriesData from '../SubmodelPlugins/TimeSeriesData.vue';
 
     export default defineComponent({
@@ -54,7 +55,7 @@
         TimeSeriesData,
         DashboardHandling,
     },
-    mixins: [DashboardHandling],
+    mixins: [SubmodelElementHandling, DashboardHandling],
     props: ['aasData', 'dashboardData'],
 
     setup() {
@@ -92,11 +93,6 @@
     },
 
     methods: {
-        checkSemanticId(semanticId: string): boolean {
-            // console.log(this.dashboardData)
-            return this.dashboardData.configObject.semanticId === semanticId;
-        },
-
         async getAvailableGroups() {
             this.groups = await this.getGroups();
         },

--- a/aas-gui/Frontend/aas-web-gui/src/components/Dashboard/DashboardElement.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/Dashboard/DashboardElement.vue
@@ -24,7 +24,7 @@
             </v-col>
         </v-row>
         <template v-if="AASData && Object.keys(AASData).length > 0">
-            <TimeSeriesData v-if="checkSemanticId('https://admin-shell.io/idta/TimeSeries/1/1')" :submodelElementData="AASData" :configData="localDashboardData" :editDialog="false" :loadTrigger="trigger"></TimeSeriesData>
+            <TimeSeriesData v-if="checkSemanticId(localDashboardData.configObject, 'https://admin-shell.io/idta/TimeSeries/1/1')" :submodelElementData="AASData" :configData="localDashboardData" :editDialog="false" :loadTrigger="trigger"></TimeSeriesData>
         </template>
     </v-card>
     <!-- Dialog for deleting a dashboard element -->
@@ -45,6 +45,7 @@
 import { defineComponent } from 'vue';
 import { useEnvStore } from '@/store/EnvironmentStore';
 import DashboardHandling from '@/mixins/DashboardHandling';
+import SubmodelElementHandling from '@/mixins/SubmodelElementHandling';
 import TimeSeriesData from '../SubmodelPlugins/TimeSeriesData.vue';
 import DashboardEditElement from '../Dashboard/DashboardEditElement.vue';
 
@@ -55,7 +56,7 @@ export default defineComponent({
         TimeSeriesData,
         DashboardEditElement,
     },
-    mixins: [DashboardHandling],
+    mixins: [SubmodelElementHandling, DashboardHandling],
     props: ['dashboardData', 'globalSyncStatus'],
     emits: ['deleteElement', 'updateElement'],
 
@@ -133,10 +134,6 @@ export default defineComponent({
                 }
             });
 
-        },
-        // Function to check if the SemanticID of a SubmodelElement matches the given SemanticID
-        checkSemanticId(semanticId: string): boolean {
-            return this.localDashboardData.configObject.semanticId === semanticId;
         },
 
         updateVisibility() {

--- a/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/HandoverDocumentation.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/HandoverDocumentation.vue
@@ -212,7 +212,7 @@ export default defineComponent({
             submodelElementData = await this.calculateSubmodelElementPathes(submodelElementData, this.SelectedNode.path);
             // create array of documents
             let documents = this.submodelElementData.submodelElements.filter((element: any) => {
-                return element.semanticId.keys[0].value.includes("0173-1#02-ABI500#001/0173-1#01-AHF579#001");
+                return this.checkSemanticId(element, '0173-1#02-ABI500#001/0173-1#01-AHF579#001');
             });
             documents.forEach((document: any) => {
                 this.extractDocumentVersions(document);
@@ -227,7 +227,7 @@ export default defineComponent({
         extractDocumentVersions(document: any) {
             // create an array with every DocumentVersion SubmodelElementCollection
             document.documentVersions = document.value.filter((element: any) => {
-                return element.semanticId && element.semanticId.keys && element.semanticId.keys.length > 0 && element.semanticId.keys[0].value.includes("0173-1#02-ABI503#001/0173-1#01-AHF582#001");
+                return element.semanticId && element.semanticId.keys && element.semanticId.keys.length > 0 && this.checkSemanticId(element, '0173-1#02-ABI503#001/0173-1#01-AHF582#001');
             });
             // prepare each DocumentVersion
             document.documentVersions.forEach((documentVersion: any) => {
@@ -246,13 +246,13 @@ export default defineComponent({
 
         extractDocumentIds(document: any) {
             document.documentIds = document.value.filter((element: any) => {
-                return element.semanticId && element.semanticId.keys && element.semanticId.keys.length > 0 && element.semanticId.keys[0].value.includes("0173-1#02-ABI501#001/0173-1#01-AHF580#001");
+                return element.semanticId && element.semanticId.keys && element.semanticId.keys.length > 0 && this.checkSemanticId(element, '0173-1#02-ABI501#001/0173-1#01-AHF580#001');
             });
         },
 
         extractDocumentClassifications(document: any) {
             document.documentClassifications = document.value.filter((element: any) => {
-                return element.semanticId && element.semanticId.keys && element.semanticId.keys.length > 0 && element.semanticId.keys[0].value.includes("0173-1#02-ABI502#001/0173-1#01-AHF581#001*02");
+                return element.semanticId && element.semanticId.keys && element.semanticId.keys.length > 0 && this.checkSemanticId(element, '0173-1#02-ABI502#001/0173-1#01-AHF581#001*02');
             });
         },
 
@@ -275,7 +275,7 @@ export default defineComponent({
 
         getElementBySemanticId(semanticId: string, parentElement: any) {
             return parentElement.value.find((element: any) => {
-                return element.semanticId && element.semanticId.keys && element.semanticId.keys.length > 0 && element.semanticId.keys[0].value.includes(semanticId);
+                return element.semanticId && element.semanticId.keys && element.semanticId.keys.length > 0 && this.checkSemanticId(element, semanticId);
             });
         },
     },

--- a/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/_SubmodelEntrypoint.vue
+++ b/aas-gui/Frontend/aas-web-gui/src/components/SubmodelPlugins/_SubmodelEntrypoint.vue
@@ -2,14 +2,14 @@
     <v-container fluid class="pa-0">
         <!-- List of all available Submodel and SubmodelElement Plugins matched by their SemanticID -->
         <template v-if="SelectedNode && Object.keys(SelectedNode).length > 0 && Object.keys(submodelElementData).length > 0 && submodelElementData.semanticId && submodelElementData.semanticId.keys && submodelElementData.semanticId.keys.length > 0">
-            <HTWFuehrungskomponente v-if="checkSemanticId('http://htw-berlin.de/smc_statemachine')" :submodelElementData="submodelElementData" :selectedNode="selectedNode"></HTWFuehrungskomponente>
-            <DigitalNameplate v-else-if="checkSemanticId('https://admin-shell.io/zvei/nameplate/2/0/Nameplate')" :submodelElementData="submodelElementData"></DigitalNameplate>
-            <TimeSeriesData v-else-if="checkSemanticId('https://admin-shell.io/idta/TimeSeries/1/1')" :submodelElementData="submodelElementData"></TimeSeriesData>
-            <BillsOfMaterial v-else-if="checkSemanticId('https://admin-shell.io/idta/HierarchicalStructures/1/0/Submodel') || checkSemanticId('https://admin-shell.io/idta/HierarchicalStructures/1/1/Submodel')" :submodelElementData="submodelElementData"></BillsOfMaterial>
-            <HandoverDocumentation v-else-if="checkSemanticId('0173-1#01-AHF578#001')" :submodelElementData="submodelElementData"></HandoverDocumentation>
-            <ContactInformation v-else-if="checkSemanticId('https://admin-shell.io/zvei/nameplate/1/0/ContactInformations')" :submodelElementData="submodelElementData"></ContactInformation>
-            <TechnicalData v-else-if="checkSemanticId('https://admin-shell.io/ZVEI/TechnicalData/Submodel/1/2')" :submodelElementData="submodelElementData"></TechnicalData>
-            <JSONArrayProperty v-else-if="checkSemanticId('http://iese.fraunhofer.de/prop_jsonarray')" :submodelElementData="submodelElementData"></JSONArrayProperty>
+            <HTWFuehrungskomponente v-if="checkSemanticId(submodelElementData, 'http://htw-berlin.de/smc_statemachine')" :submodelElementData="submodelElementData" :selectedNode="selectedNode"></HTWFuehrungskomponente>
+            <DigitalNameplate v-else-if="checkSemanticId(submodelElementData, 'https://admin-shell.io/zvei/nameplate/2/0/Nameplate')" :submodelElementData="submodelElementData"></DigitalNameplate>
+            <TimeSeriesData v-else-if="checkSemanticId(submodelElementData, 'https://admin-shell.io/idta/TimeSeries/1/1')" :submodelElementData="submodelElementData"></TimeSeriesData>
+            <BillsOfMaterial v-else-if="checkSemanticId(submodelElementData, 'https://admin-shell.io/idta/HierarchicalStructures/1/0/Submodel') || checkSemanticId(submodelElementData, 'https://admin-shell.io/idta/HierarchicalStructures/1/1/Submodel')" :submodelElementData="submodelElementData"></BillsOfMaterial>
+            <HandoverDocumentation v-else-if="checkSemanticId(submodelElementData, '0173-1#01-AHF578#001')" :submodelElementData="submodelElementData"></HandoverDocumentation>
+            <ContactInformation v-else-if="checkSemanticId(submodelElementData, 'https://admin-shell.io/zvei/nameplate/1/0/ContactInformations')" :submodelElementData="submodelElementData"></ContactInformation>
+            <TechnicalData v-else-if="checkSemanticId(submodelElementData, 'https://admin-shell.io/ZVEI/TechnicalData/Submodel/1/2')" :submodelElementData="submodelElementData"></TechnicalData>
+            <JSONArrayProperty v-else-if="checkSemanticId(submodelElementData, 'http://iese.fraunhofer.de/prop_jsonarray')" :submodelElementData="submodelElementData"></JSONArrayProperty>
             <GenericDataVisu v-else-if="viewerMode" :submodelElementData="submodelElementData.submodelElements"></GenericDataVisu>
             <!-- Plugins added by the user are dynamically registered here -->
             <component v-for="(plugin, i) in filteredPlugins" :key="i" :is="plugin.name" :submodelElementData="submodelElementData"></component>
@@ -31,6 +31,7 @@ import { defineComponent } from 'vue';
 import { useRoute } from 'vue-router';
 import { useNavigationStore } from '@/store/NavigationStore';
 import { useAASStore } from '@/store/AASDataStore';
+import SubmodelElementHandling from '@/mixins/SubmodelElementHandling';
 
 import HTWFuehrungskomponente from './HTWFuehrungskomponente.vue';
 import DigitalNameplate from './DigitalNameplate.vue';
@@ -62,6 +63,7 @@ export default defineComponent({
         PDFPreview,
         CADPreview,
     },
+    mixins: [SubmodelElementHandling],
     props: ['submodelElementData', 'selectedNode'],
 
     setup() {
@@ -102,17 +104,5 @@ export default defineComponent({
         },
     },
 
-    methods: {
-        // Function to check if the SemanticID of a SubmodelElement matches the given SemanticID
-        checkSemanticId(semanticId: string): boolean {
-            let result = false;
-            this.submodelElementData.semanticId.keys.forEach((key: any) => {
-                if (key.value === semanticId) {
-                    result = true;
-                }
-            });
-            return result;
-        },
-    },
 });
 </script>

--- a/aas-gui/Frontend/aas-web-gui/src/mixins/SubmodelElementHandling.ts
+++ b/aas-gui/Frontend/aas-web-gui/src/mixins/SubmodelElementHandling.ts
@@ -101,12 +101,39 @@ export default defineComponent({
         },
 
         // Function to check if the SemanticID of a SubmodelElement matches the given SemanticID
-        checkSemanticId(submodelElementData: any, semanticId: string): boolean {
+        checkSemanticId(submodelElement: any, semanticId: string): boolean {
+
+            if (semanticId.trim() == '') return false;
+
+            if (!submodelElement.semanticId
+                || !submodelElement.semanticId.keys
+                ||  submodelElement.semanticId.keys.length == 0) return false;
+
             let result = false;
-            submodelElementData.semanticId.keys.forEach((key: any) => {
-                if (key.value === semanticId) {
-                    result = true;
+            submodelElement.semanticId.keys.forEach((key: any) => {
+
+                if (key.value.startsWith('http://') || 'https://') {
+                    // e.g. IDTA IRI like
+                    if (new RegExp('\/\d\/\d\/{0,1}' + '$').test(semanticId)) {
+                        if (key.value === semanticId) result = true;
+                    } else {
+                        if (key.value.startsWith(semanticId)) result = true;
+                    }
+                } else if (key.value.startsWith('0173-1')) {
+                    // ECLASS IRDI like 0173-1#01-AHF578#001 resp. 0173-1-01-AHF578-001
+                    if (new RegExp('[#-]{1}\d{3}$').test(semanticId)) {
+                        // ECLASS IRDI with version (like 0173-1#01-AHF578#001 resp. 0173-1-01-AHF578-001)
+                        if (key.value === semanticId) result = true;
+                    } else {
+                        // ECLASS IRDI without version (like 0173-1#01-AHF578 resp. 0173-1-01-AHF578)
+                        if (key.value.startsWith(semanticId)) result = true;
+                    }
+                } else {
+                    console.log('5 submodelElement.semanticId.keys', key.value, semanticId);
+                    if (key.value === semanticId) result = true;
                 }
+
+            
             });
             return result;
         },

--- a/aas-gui/Frontend/aas-web-gui/src/mixins/SubmodelElementHandling.ts
+++ b/aas-gui/Frontend/aas-web-gui/src/mixins/SubmodelElementHandling.ts
@@ -109,32 +109,31 @@ export default defineComponent({
                 || !submodelElement.semanticId.keys
                 ||  submodelElement.semanticId.keys.length == 0) return false;
 
-            let result = false;
-            submodelElement.semanticId.keys.forEach((key: any) => {
+            for (const key of  submodelElement.semanticId.keys) {
 
                 if (key.value.startsWith('http://') || 'https://') {
                     // e.g. IDTA IRI like
                     if (new RegExp('\/\d\/\d\/{0,1}' + '$').test(semanticId)) {
-                        if (key.value === semanticId) result = true;
+                        if (key.value === semanticId) return true;
                     } else {
-                        if (key.value.startsWith(semanticId)) result = true;
+                        if (key.value.startsWith(semanticId)) return true;
                     }
                 } else if (key.value.startsWith('0173-1')) {
                     // ECLASS IRDI like 0173-1#01-AHF578#001 resp. 0173-1-01-AHF578-001
                     if (new RegExp('[#-]{1}\d{3}$').test(semanticId)) {
                         // ECLASS IRDI with version (like 0173-1#01-AHF578#001 resp. 0173-1-01-AHF578-001)
-                        if (key.value === semanticId) result = true;
+                        if (key.value === semanticId) return true;
                     } else {
                         // ECLASS IRDI without version (like 0173-1#01-AHF578 resp. 0173-1-01-AHF578)
-                        if (key.value.startsWith(semanticId)) result = true;
+                        if (key.value.startsWith(semanticId)) return true;
                     }
                 } else {
-                    if (key.value === semanticId) result = true;
+                    if (key.value === semanticId) return true;
                 }
 
             
-            });
-            return result;
+            }
+            return false;
         },
 
         // Function to check if the valueType is a number

--- a/aas-gui/Frontend/aas-web-gui/src/mixins/SubmodelElementHandling.ts
+++ b/aas-gui/Frontend/aas-web-gui/src/mixins/SubmodelElementHandling.ts
@@ -129,7 +129,6 @@ export default defineComponent({
                         if (key.value.startsWith(semanticId)) result = true;
                     }
                 } else {
-                    console.log('5 submodelElement.semanticId.keys', key.value, semanticId);
                     if (key.value === semanticId) result = true;
                 }
 


### PR DESCRIPTION
- Reduces redundancies of checking semantiId
- Usage of checkSemanticId-feature in other relevant components
- Add possibility to check semanticId without considering the version
- checkSemanticId distinguishs between IRI and (ECLASS) IRDIs

This PR can be seen as a preparatory measure to make it easier to use new SMTs or new semanticIds in general.